### PR TITLE
Fixed getting multiple events from socket

### DIFF
--- a/client/components/controllers/Controller.js
+++ b/client/components/controllers/Controller.js
@@ -29,10 +29,6 @@ import {
 } from '../../../server/socket/events'
 
 class Controller extends Component {
-  // state = {
-  //   value: 0
-  // }
-
   componentDidMount() {
     socket.removeAllListeners([
       EVENT_STARTED,
@@ -99,8 +95,6 @@ class Controller extends Component {
   componentWillUnmount() {
     socket.removeAllListeners()
     // Make sure to clean up all socket events in case this is re-rendered.
-    // console.log(`Removed listeners`)
-    // socket.removeAllListeners([EVENT_STARTED, NEXT_ROUND, EVENT_ENDED, START_EVENT, END_EVENT, REQUEST_NEXT_ROUND])
   }
 
   randomPrompt = () => {

--- a/client/components/controllers/Controller.js
+++ b/client/components/controllers/Controller.js
@@ -11,7 +11,6 @@ import {
   updateEventStatus,
   getRoundInteraction,
   getDisplayShape,
-
   isEventDone,
   getRound,
   getPrompt
@@ -25,7 +24,8 @@ import {
   NEXT_ROUND,
   ROOM,
   EVENT_PREFIX,
-  EVENT_ENDED
+  EVENT_ENDED,
+  END_EVENT
 } from '../../../server/socket/events'
 
 class Controller extends Component {
@@ -34,6 +34,14 @@ class Controller extends Component {
   // }
 
   componentDidMount() {
+    socket.removeAllListeners([
+      EVENT_STARTED,
+      NEXT_ROUND,
+      EVENT_ENDED,
+      START_EVENT,
+      END_EVENT,
+      REQUEST_NEXT_ROUND
+    ])
     /*
     *   Load in State
     */
@@ -65,6 +73,8 @@ class Controller extends Component {
       })
     })
 
+    const startFunc = ({eventId}) => {}
+
     socket.on(EVENT_ENDED, ({eventId}) => {
       console.log(`Got ${EVENT_ENDED} with payload=`, eventId)
       this.props.updateEventStatus({
@@ -87,8 +97,10 @@ class Controller extends Component {
   }
 
   componentWillUnmount() {
+    socket.removeAllListeners()
     // Make sure to clean up all socket events in case this is re-rendered.
-    socket.removeAllListeners([EVENT_STARTED, NEXT_ROUND, EVENT_ENDED])
+    // console.log(`Removed listeners`)
+    // socket.removeAllListeners([EVENT_STARTED, NEXT_ROUND, EVENT_ENDED, START_EVENT, END_EVENT, REQUEST_NEXT_ROUND])
   }
 
   randomPrompt = () => {

--- a/client/components/eventControl.js
+++ b/client/components/eventControl.js
@@ -39,6 +39,7 @@ class EventControl extends React.Component {
   }
 
   nextRoundWrapper = (eventId, currRound) => {
+    console.log('this is the current round', currRound)
     if (currRound >= 4) {
       //do nothing
     } else {

--- a/client/components/eventControl.js
+++ b/client/components/eventControl.js
@@ -39,7 +39,6 @@ class EventControl extends React.Component {
   }
 
   nextRoundWrapper = (eventId, currRound) => {
-    console.log('this is the current round', currRound)
     if (currRound >= 4) {
       //do nothing
     } else {

--- a/client/store/event.js
+++ b/client/store/event.js
@@ -158,7 +158,7 @@ export default function(state = defaultEvents, action) {
     case RESET_ROUNDS: {
       return {
         byId: {...state.byId},
-        round: 1
+        round: 2
       }
     }
     default:


### PR DESCRIPTION
There was a weird issue where when using removeAllListeners([EVENT_NAMES]) with the parameter being an array of the EVENT_NAMES to remove, it didn't do anything. I tried commenting it out and running it again, and the same behavior was occurring which led me to believe that removeAllListeners([EVENT_NAMES]) was not doing anything. I then just tried removeAllListeners() without a parameter and the socket events were not duplicating.

I also did a quick and dirty fix to clicking the next round button twice for the first time. I just set the initial redux store value of the round number to be 2, since we manually set the first round to 1 when we initialize the game.

Closes #147 Closes #149 

So apparently, the removeAllListeners() in the componentDidMount is needed with the parameters of all the EVENT_NAMES, AND the empty parameter removeAllListeners() is also needed in the componentDidUnmount. I'm not sure why...